### PR TITLE
Edison format xyz: Checking for any EMPTY line

### DIFF
--- a/bw1s1.xyz
+++ b/bw1s1.xyz
@@ -1,4 +1,4 @@
-  4
+   4 
       file 'w1s1.log' was gotten at: ---' #p mp2=full gen pseudo=Read opt freq'---
 14      -0.2251299774      0.0000000026      0.0107392362
 au       1.8213760892      0.0000000800     -0.0901652030

--- a/functions.py
+++ b/functions.py
@@ -333,7 +333,8 @@ def format_xyz(file_xyz):
 
             # - checking empty lines. Only line number two has a free format
             if len(values) == 0 and line_number != 2:
-                error_message += f'\n | line {line_number} is empty\n'
+                error_message += f'\n | line {line_number} is empty'
+                error_message += f'\n | Only line number two has a free format and could be empty\n'
                 continue
 
             # - firts line is number of atoms

--- a/functions.py
+++ b/functions.py
@@ -331,6 +331,11 @@ def format_xyz(file_xyz):
             line_number += 1
             values = [i for i in line.split()]
 
+            # - checking empty lines. Only line number two has a free format
+            if len(values) == 0 and line_number != 2:
+                error_message += f'\n | line {line_number} is empty\n'
+                continue
+
             # - firts line is number of atoms
             if line_number == 1:
                 try:


### PR DESCRIPTION
Ya incluí una forma de revisar que los archivos XYZ no contengan líneas vacías. Solo la linea número dos tiene un formato libre y podría estar vacía, todas las demás líneas deben contener por lo menos un valor. Tampoco pueden haber lineas vacías al final de las coordenadas. La última linea debe contener el símbolo y las coordendas del último átomo.

Archivo modificado "functions.py" en las línea 334-338